### PR TITLE
Check that vendor/autoload.php exists

### DIFF
--- a/PropertySuggester.php
+++ b/PropertySuggester.php
@@ -11,7 +11,9 @@ if ( defined( 'PropertySuggester_VERSION' ) ) {
 
 define( 'PropertySuggester_VERSION', '0.1' );
 
-require_once __DIR__ . '/vendor/autoload.php';
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
 
 global $wgExtensionCredits;
 $wgExtensionCredits['other'][] = array(


### PR DESCRIPTION
If we install property suggester via composer, by including it in the Wikidata "build", in MediaWiki's composer.json or other such setup then autoload.php will be elsewhere and handled elsewhere.
