### PR TITLE
Fix remoteExtPath for installation in non-standard locations

### DIFF
--- a/PropertySuggester.php
+++ b/PropertySuggester.php
@@ -39,11 +39,15 @@ $wgHooks['BeforePageDisplay'][] = 'PropertySuggesterHooks::onBeforePageDisplay';
 $wgHooks['UnitTestsList'][] = 'PropertySuggesterHooks::onUnitTestsList';
 $wgHooks['LoadExtensionSchemaUpdates'][] = 'PropertySuggesterHooks::onCreateSchema';
 
+$remoteExtPathParts = explode(
+	DIRECTORY_SEPARATOR . 'extensions' . DIRECTORY_SEPARATOR, __DIR__, 2
+);
+
 $wgResourceModules['ext.PropertySuggester.EntitySelector'] = array(
 	'scripts'       => array( 'modules/ext.PropertySuggester.EntitySelector.js' ),
 	'dependencies'  => array( 'jquery.wikibase.entityselector' ),
 	'localBasePath' => __DIR__,
-	'remoteExtPath' => 'PropertySuggester',
+	'remoteExtPath' => $remoteExtPathParts[1],
 );
 
 


### PR DESCRIPTION
Same hack used in Wikibase, ValueView, etc. to allow this to work if an extension is installed in a non-standard place.
