### PR TITLE
Restrict input for 'context' in GetSuggestions api module

### DIFF
--- a/src/PropertySuggester/GetSuggestions.php
+++ b/src/PropertySuggester/GetSuggestions.php
@@ -155,7 +155,7 @@ class GetSuggestions extends ApiBase {
 				ApiBase::PARAM_DFLT => $this->getContext()->getLanguage()->getCode(),
 			),
 			'context' => array(
-				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_TYPE => array( 'item', 'qualifier', 'reference' ),
 				ApiBase::PARAM_DFLT => 'item',
 			),
 			'search' => array(

--- a/tests/phpunit/PropertySuggester/GetSuggestionsTest.php
+++ b/tests/phpunit/PropertySuggester/GetSuggestionsTest.php
@@ -115,6 +115,18 @@ class GetSuggestionTest extends WikibaseApiTestCase {
 		$this->assertCount( 0, $result['search'] );
 	}
 
+	public function testExecutionWithInvalidContext() {
+		$p56 = self::$idMap['%P56%'];
+		$params = array(
+			'action' => 'wbsgetsuggestions',
+			'properties' => $p56,
+			'context' => 'delete all the things!'
+		);
+
+		$this->setExpectedException( 'UsageException' );
+		$res = $this->doApiRequest( $params );
+	}
+
 	public function testGetAllowedParams() {
 		$this->assertNotEmpty( $this->getSuggestions->getAllowedParams() );
 	}


### PR DESCRIPTION
Fixed #94
