### PR TITLE
Fix MW Install script

### DIFF
--- a/build/travis/before_script.sh
+++ b/build/travis/before_script.sh
@@ -12,7 +12,7 @@ cd ..
 wget https://github.com/wikimedia/mediawiki-core/archive/master.tar.gz
 tar -zxf master.tar.gz
 rm master.tar.gz
-mv mediawiki-core-master wiki
+mv mediawiki-master wiki
 
 # checkout wikibase
 wget https://github.com/wikimedia/mediawiki-extensions-Wikibase/archive/master.tar.gz


### PR DESCRIPTION
Seems the folder name inside the tar.gz has changed recently causing the MW installation to fail.
