### PR TITLE
Suggestions for empty items

### DIFF
--- a/src/PropertySuggester/GetSuggestions.php
+++ b/src/PropertySuggester/GetSuggestions.php
@@ -5,6 +5,7 @@ namespace PropertySuggester;
 use ApiBase;
 use ApiMain;
 use DerivativeRequest;
+use ObjectCache;
 use PropertySuggester\Suggesters\SimpleSuggester;
 use PropertySuggester\Suggesters\SuggesterEngine;
 use Wikibase\DataModel\Entity\Property;
@@ -58,13 +59,20 @@ class GetSuggestions extends ApiBase {
 
 		$wikibaseRepo = WikibaseRepo::getDefaultInstance();
 		$store = $wikibaseRepo->getStore();
+		$settings = $wikibaseRepo->getSettings();
 
 		$this->termIndex = $store->getTermIndex();
 		$this->entityLookup = $store->getEntityLookup();
 		$this->entityTitleLookup = $wikibaseRepo->getEntityTitleLookup();
 		$this->languageCodes = $wikibaseRepo->getTermsLanguages()->getLanguages();
 
-		$this->suggester = new SimpleSuggester( wfGetLB() );
+		$this->suggester = new SimpleSuggester(
+			wfGetLB(),
+			ObjectCache::getInstance( $settings->getSetting( 'sharedCacheType' ) ),
+			$settings->getSetting( 'sharedCacheKeyPrefix' ),
+			$settings->getSetting( 'sharedCacheDuration' )
+		);
+
 		$this->suggester->setDeprecatedPropertyIds( $wgPropertySuggesterDeprecatedIds );
 		$this->suggester->setClassifyingPropertyIds( $wgPropertySuggesterClassifyingPropertyIds );
 

--- a/src/PropertySuggester/Suggesters/SimpleSuggester.php
+++ b/src/PropertySuggester/Suggesters/SimpleSuggester.php
@@ -160,8 +160,8 @@ class SimpleSuggester implements SuggesterEngine {
 
 	/**
 	 * @param DatabaseBase $dbr
-	 * @param int[] $propertyIds
-	 * @param string[] $idTuples
+	 * @param int[] $propertyIds used property ids in an item.
+	 * @param string[] $idTuples numericPropertyId => numericEntityId pairs used in an item.
 	 * @param string $context
 	 *
 	 * @return string[]

--- a/tests/phpunit/PropertySuggester/Suggesters/SimpleSuggesterTest.php
+++ b/tests/phpunit/PropertySuggester/Suggesters/SimpleSuggesterTest.php
@@ -68,8 +68,7 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	}
 
 	public function testSuggestByItem() {
-		$item = new Item();
-		$item->setId( new ItemId( 'Q42' ) );
+		$item = new Item( new ItemId( 'Q42' ) );
 		$statement = new Statement( new Claim( new PropertySomeValueSnak( new PropertyId( 'P1' ) ) ) );
 		$statement->setGuid( 'claim0' );
 		$item->addClaim( $statement );

--- a/tests/phpunit/PropertySuggester/Suggesters/SimpleSuggesterTest.php
+++ b/tests/phpunit/PropertySuggester/Suggesters/SimpleSuggesterTest.php
@@ -48,7 +48,7 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 
 		$this->tablesUsed[] = 'wbs_propertypairs';
 		$lb = new LoadBalancerSingle( array("connection" => $this->db ) );
-		$this->suggester = new SimpleSuggester( $lb );
+		$this->suggester = new SimpleSuggester( $lb, wfGetMainCache(), 'cacheprefix', 3600 );
 	}
 
 	public function testDatabaseHasRows() {
@@ -68,7 +68,7 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	}
 
 	public function testSuggestByItem() {
-		$item = Item::newEmpty();
+		$item = new Item();
 		$item->setId( new ItemId( 'Q42' ) );
 		$statement = new Statement( new Claim( new PropertySomeValueSnak( new PropertyId( 'P1' ) ) ) );
 		$statement->setGuid( 'claim0' );
@@ -78,6 +78,11 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 
 		$this->assertEquals( new PropertyId( 'p2' ), $res[0]->getPropertyId() );
 		$this->assertEquals( new PropertyId( 'p3' ), $res[1]->getPropertyId() );
+	}
+
+	public function testSuggestByItem_emptyItem() {
+		$res = $this->suggester->suggestByItem( new Item(), 100, 0.0, 'item' );
+		$this->assertCount( 4, $res );
 	}
 
 	public function testDeprecatedProperties() {
@@ -100,14 +105,14 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	 * @expectedException InvalidArgumentException
 	 */
 	public function testInvalidLimit() {
-		$this->suggester->suggestByPropertyIds( array(), '10', 0.01, 'item' );
+		$this->suggester->suggestByPropertyIds( array( new PropertyId( 'p1' ) ), '10', 0.01, 'item' );
 	}
 
 	/**
 	 * @expectedException InvalidArgumentException
 	 */
 	public function testInvalidMinProbability() {
-		$this->suggester->suggestByPropertyIds( array(), 10, '0.01', 'item' );
+		$this->suggester->suggestByPropertyIds( array( new PropertyId( 'p1' ) ), 10, '0.01', 'item' );
 	}
 
 }


### PR DESCRIPTION
There used to be (?) suggestions (e.g. P31) for items with no statements yet.

This provides suggestions by item when there are no property ids used yet on the item, suggesting overall most used properties like P31 that users may want to start with on an empty item.

Bug: T92748