### PR TITLE
Adjust api code for core api changes

### DIFF
--- a/src/PropertySuggester/GetSuggestions.php
+++ b/src/PropertySuggester/GetSuggestions.php
@@ -4,6 +4,7 @@ namespace PropertySuggester;
 
 use ApiBase;
 use ApiMain;
+use ApiResult;
 use DerivativeRequest;
 use PropertySuggester\Suggesters\SimpleSuggester;
 use PropertySuggester\Suggesters\SuggesterEngine;
@@ -101,7 +102,7 @@ class GetSuggestions extends ApiBase {
 
 		// Define Result
 		$slicedEntries = array_slice( $entries, $params->continue, $params->limit );
-		$this->getResult()->setIndexedTagName( $slicedEntries, 'search' );
+		ApiResult::setIndexedTagName( $slicedEntries, 'search' );
 		$this->getResult()->addValue( null, 'search', $slicedEntries );
 
 		$this->getResult()->addValue( null, 'success', 1 );
@@ -130,11 +131,20 @@ class GetSuggestions extends ApiBase {
 				'type' => Property::ENTITY_TYPE
 			)
 		);
+
 		$api = new ApiMain( $searchEntitiesParameters );
 		$api->execute();
-		$apiResult = $api->getResultData();
-		$searchResult = $apiResult['search'];
-		return $searchResult;
+
+		$apiResult = $api->getResult()->getResultData(
+			null,
+			array(
+				'BC' => array(),
+				'Types' => array(),
+				'Strip' => 'all'
+			)
+		);
+
+		return $apiResult['search'];
 	}
 
 	/**

--- a/src/PropertySuggester/ResultBuilder.php
+++ b/src/PropertySuggester/ResultBuilder.php
@@ -139,7 +139,7 @@ class ResultBuilder {
 		if ( preg_match( $this->searchPattern, $term->getText() ) ) {
 			if ( !isset( $entry['aliases'] ) ) {
 				$entry['aliases'] = array();
-				$this->result->setIndexedTagName( $entry['aliases'], 'alias' );
+				ApiResult::setIndexedTagName( $entry['aliases'], 'alias' );
 			}
 			$entry['aliases'][] = $term->getText();
 		}

--- a/tests/phpunit/PropertySuggester/ResultBuilderTest.php
+++ b/tests/phpunit/PropertySuggester/ResultBuilderTest.php
@@ -20,11 +20,10 @@ class ResultBuilderTest extends MediaWikiTestCase {
 
 	public function setUp() {
 		parent::setUp();
-		$apiMain =  $this->getMockBuilder( 'ApiMain' )->disableOriginalConstructor()->getMockForAbstractClass();
 
 		$entityTitleLookup = $this->getMock( 'Wikibase\Lib\Store\EntityTitleLookup' );
 		$termIndex = $this->getMock( 'Wikibase\TermIndex' );
-		$result = new ApiResult( $apiMain );
+		$result = new ApiResult( false ); // $maxSize, no limit
 
 		$this->resultBuilder = new ResultBuilder( $result, $termIndex, $entityTitleLookup, '' );
 	}


### PR DESCRIPTION
* use ApiResult::setIndexedTagName
* don't pass ApiMain as a constructor param for ApiResult
* use ApiResult::getResultData with transformations

Bug: T96833