### PR TITLE
Remove usage of TermIndex::getMatchingIDs

### DIFF
--- a/src/PropertySuggester/SuggestionGenerator.php
+++ b/src/PropertySuggester/SuggestionGenerator.php
@@ -118,18 +118,16 @@ class SuggestionGenerator {
 	 * @return PropertyId[]
 	 */
 	private function getMatchingIDs( $search, $language ) {
-		$ids = $this->termIndex->getMatchingIDs(
+		$termIndexEntries = $this->termIndex->getTopMatchingTerms(
 			array(
 				new TermIndexEntry( array(
-					'termType' => TermIndexEntry::TYPE_LABEL,
-					'termLanguage' => $language,
-					'termText' => $search
-				) ),
-				new TermIndexEntry( array(
-					'termType' => TermIndexEntry::TYPE_ALIAS,
 					'termLanguage' => $language,
 					'termText' => $search
 				) )
+			),
+			array(
+				TermIndexEntry::TYPE_LABEL,
+				TermIndexEntry::TYPE_ALIAS,
 			),
 			Property::ENTITY_TYPE,
 			array(
@@ -137,6 +135,12 @@ class SuggestionGenerator {
 				'prefixSearch' => true,
 			)
 		);
+
+		$ids = array();
+		foreach ( $termIndexEntries as $entry ) {
+			$ids[] = $entry->getEntityId();
+		}
+
 		return $ids;
 	}
 

--- a/tests/phpunit/PropertySuggester/SuggestionGeneratorTest.php
+++ b/tests/phpunit/PropertySuggester/SuggestionGeneratorTest.php
@@ -14,6 +14,7 @@ use Wikibase\DataModel\Statement\Statement;
 use Wikibase\Lib\Store\EntityLookup;
 use Wikibase\TermIndex;
 use InvalidArgumentException;
+use Wikibase\TermIndexEntry;
 
 /**
  * @covers PropertySuggester\SuggestionGenerator
@@ -74,12 +75,30 @@ class SuggestionGeneratorTest extends MediaWikiTestCase {
 		$resultSize = 2;
 
 		$this->termIndex->expects( $this->any() )
-			->method( 'getMatchingIDs' )
-			->will( $this->returnValue( array( $p7, $p10, $p15, $p12 ) ) );
+			->method( 'getTopMatchingTerms' )
+			->will( $this->returnValue(
+				$this->getTermIndexEntryArrayWithIds( array( $p7, $p10, $p15, $p12 ) )
+			) );
 
 		$result = $this->suggestionGenerator->filterSuggestions( $suggestions, 'foo', 'en', $resultSize );
 
 		$this->assertEquals( array( $suggestions[0], $suggestions[2] ), $result );
+	}
+
+	/**
+	 * @param PropertyId[] $ids
+	 *
+	 * @return TermIndexEntry[]
+	 */
+	private function getTermIndexEntryArrayWithIds( $ids ) {
+		$termIndexEntries = array();
+		foreach ( $ids as $id ) {
+			$termIndexEntries[] = new TermIndexEntry( array(
+				'entityId' => $id->getNumericId(),
+				'entityType' => $id->getEntityType(),
+			) );
+		}
+		return $termIndexEntries;
 	}
 
 	public function testFilterSuggestionsWithoutSearch() {


### PR DESCRIPTION
This method had been removed from Wikibase.

Fixes #131