### PR TITLE
Remove unused i18n messages and update description and authors

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,8 +1,9 @@
 {
     "@metadata": {
-        "authors": []
+        "authors": [
+            "Christian Dullweber",
+            "Katie Filbert"
+        ]
     },
-    "propertysuggester-desc": "Shows suggested properties for wikibase items.",
-    "propertysuggester": "Property Suggester",
-    "propertysuggester-intro": "This is the PropertySuggester."
+    "propertysuggester-desc": "Suggests properties when adding Wikibase statements."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,8 +1,8 @@
 {
     "@metadata": {
-        "authors": []
+        "authors": [
+            "Christian Dullweber"
+        ]
     },
-    "propertysuggester-desc": "{{desc|name=PropertySuggester|url=http://www.mediawiki.org/wiki/Extension:PropertySuggester}}",
-    "propertysuggester": "Property Suggester",
-    "propertysuggester-intro": "introduces suggester"
+    "propertysuggester-desc": "{{desc|name=PropertySuggester|url=http://www.mediawiki.org/wiki/Extension:PropertySuggester}}"
 }


### PR DESCRIPTION
"propertysuggester" and "propertysuggester-intro" appear to be unused.

I think there was a special page at one point for the suggester and maybe the messages were used there. We don't need these messages now.

Also added authors and improved the extension description message.