### PR TITLE
Fix property suggester resource loader module not loading

### DIFF
--- a/PropertySuggesterHooks.php
+++ b/PropertySuggesterHooks.php
@@ -1,5 +1,6 @@
 <?php
 
+use Wikibase\DataModel\Entity\Item;
 use Wikibase\Repo\WikibaseRepo;
 
 final class PropertySuggesterHooks {
@@ -19,7 +20,7 @@ final class PropertySuggesterHooks {
 		}
 
 		$entityNamespaceLookup = WikibaseRepo::getDefaultInstance()->getEntityNamespaceLookup();
-		$itemNamespace = $entityNamespaceLookup->getEntityNamespace( CONTENT_MODEL_WIKIBASE_ITEM );
+		$itemNamespace = $entityNamespaceLookup->getEntityNamespace( Item::ENTITY_TYPE );
 
 		if ( $out->getTitle()->getNamespace() !== $itemNamespace ) {
 			return true;

--- a/tests/phpunit/PropertySuggester/PropertySuggesterHooksTest.php
+++ b/tests/phpunit/PropertySuggester/PropertySuggesterHooksTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PropertySuggester;
+
+use MediaWikiTestCase;
+use PropertySuggesterHooks;
+use RequestContext;
+use Title;
+use Wikibase\DataModel\Entity\EntityId;
+use Wikibase\DataModel\Entity\ItemId;
+use Wikibase\DataModel\Entity\PropertyId;
+use Wikibase\Repo\WikibaseRepo;
+
+/**
+ * @covers PropertySuggesterHooks
+ *
+ * @group PropertySuggester
+ * @group Wikibase
+ */
+class PropertySuggesterHooksTest extends MediaWikiTestCase {
+
+	public function testOnBeforePageDisplay_resourceLoaderModuleAdded() {
+		$title = $this->getTitleForId( new ItemId( 'Q1' ) );
+
+		$context = $this->getContext( $title );
+		$output = $context->getOutput();
+		$skin = $context->getSkin();
+
+		PropertySuggesterHooks::onBeforePageDisplay( $output, $skin );
+
+		$this->assertContains( 'ext.PropertySuggester.EntitySelector', $output->getModules() );
+	}
+
+	/**
+	 * @dataProvider onBeforePageDisplay_resourceLoaderModuleNotAddedProvider
+	 */
+	public function testOnBeforePageDisplay_resourceLoaderModuleNotAdded( Title $title ) {
+		$context = $this->getContext( $title );
+		$output = $context->getOutput();
+		$skin = $context->getSkin();
+
+		PropertySuggesterHooks::onBeforePageDisplay( $output, $skin );
+
+		$this->assertNotContains( 'ext.PropertySuggester.EntitySelector', $output->getModules() );
+	}
+
+	public function onBeforePageDisplay_resourceLoaderModuleNotAddedProvider() {
+		$title = $this->getTitleForId( new PropertyId( 'P1' ) );
+
+		return [
+			[ $this->getTitleForId( new PropertyId( 'P1' ) ) ],
+			[ Title::makeTitle( NS_HELP, 'Contents' ) ]
+		];
+	}
+
+	private function getTitleForId( EntityId $entityId ) {
+		$entityContentFactory = WikibaseRepo::getDefaultInstance()->getEntityContentFactory();
+		return $entityContentFactory->getTitleForId( $entityId );
+	}
+
+	private function getContext( Title $title ) {
+		$context = RequestContext::getMain();
+		$context->setTitle( $title );
+
+		return $context;
+	}
+
+}


### PR DESCRIPTION
Since https://gerrit.wikimedia.org/r/#/c/289393/, we need to switch to use entity types for entity namespace lookup instead of content model ids.

Also added some tests for PropertySuggesterHooks.

Bug: T138059