### PR TITLE
Add backwards compatibility code in PropertySuggesterHooks

### DIFF
--- a/PropertySuggesterHooks.php
+++ b/PropertySuggesterHooks.php
@@ -22,6 +22,14 @@ final class PropertySuggesterHooks {
 		$entityNamespaceLookup = WikibaseRepo::getDefaultInstance()->getEntityNamespaceLookup();
 		$itemNamespace = $entityNamespaceLookup->getEntityNamespace( Item::ENTITY_TYPE );
 
+		if ( $itemNamespace === false ) {
+			// try looking up namespace by content model, for any instances of PropertySuggester
+			// running with older Wikibase prior to ef622b1bc.
+			$itemNamespace = $entityNamespaceLookup->getEntityNamespace(
+				CONTENT_MODEL_WIKIBASE_ITEM
+			);
+		}
+
 		if ( $out->getTitle()->getNamespace() !== $itemNamespace ) {
 			return true;
 		}


### PR DESCRIPTION
so that PropertySuggester still works with older versions of Wikibase prior to ef622b1bc and so that we don't have to make a breaking release.