### PR TITLE
Adapt EntitySelector to reworked _cache

### DIFF
--- a/PropertySuggester.php
+++ b/PropertySuggester.php
@@ -9,7 +9,7 @@ if ( defined( 'PropertySuggester_VERSION' ) ) {
 	return;
 }
 
-define( 'PropertySuggester_VERSION', '3.1.1' );
+define( 'PropertySuggester_VERSION', '3.1.2' );
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ generate this data from a wikidata dump.
 
 ## Release notes
 
+### 3.1.2 (2016-08-04)
+* Follow up fix for entity suggester, update cache management in EntitySuggester.
+
 ### 3.1.1 (2016-08-03)
 * Follow up fix for entity suggester, update method call in EntitySuggester.
 

--- a/modules/ext.PropertySuggester.EntitySelector.js
+++ b/modules/ext.PropertySuggester.EntitySelector.js
@@ -52,9 +52,10 @@
 					search: term,
 					context: this._getPropertyContext(),
 					format: 'json',
-					language: self.options.language,
-					'continue': self._cache[term] && self._cache[term].nextSuggestionOffset
-						? self._cache[term].nextSuggestionOffset : 0
+					language: this.options.language,
+					'continue': this._cache.term === term && this._cache.nextSuggestionOffset
+						? this._cache.nextSuggestionOffset
+						: 0
 				};
 				if( data.context == 'item' ) {
 					data.entity = self._getEntity().getId();


### PR DESCRIPTION
This is an other change in `jQuery.wikibase.entityselector` that must be reflected here. This means the "more" buttons are broken in a way that they show the same 10 entities again and again.

[Bug: T141955](https://phabricator.wikimedia.org/T141955)