### PR TITLE
Make EntityNamespaceLookup usages more bullet proof

### DIFF
--- a/PropertySuggesterHooks.php
+++ b/PropertySuggesterHooks.php
@@ -22,7 +22,7 @@ final class PropertySuggesterHooks {
 		$entityNamespaceLookup = WikibaseRepo::getDefaultInstance()->getEntityNamespaceLookup();
 		$itemNamespace = $entityNamespaceLookup->getEntityNamespace( Item::ENTITY_TYPE );
 
-		if ( $itemNamespace === false ) {
+		if ( !is_int( $itemNamespace ) ) {
 			// try looking up namespace by content model, for any instances of PropertySuggester
 			// running with older Wikibase prior to ef622b1bc.
 			$itemNamespace = $entityNamespaceLookup->getEntityNamespace(


### PR DESCRIPTION
I would like to update this API to return null instead of false.