### PR TITLE
Allow changing the weight given to classifying conditions

### DIFF
--- a/PropertySuggester.php
+++ b/PropertySuggester.php
@@ -70,5 +70,9 @@ $wgPropertySuggesterInitialSuggestions = array(
 	31, // instance of
 	279 // subclass of
 );
+
 global $wgPropertySuggesterMinProbability;
 $wgPropertySuggesterMinProbability = 0.05;
+
+global $wgPropertySuggesterClassifyingConditionWeight;
+$wgPropertySuggesterClassifyingConditionWeight = 0.5;

--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ generate this data from a wikidata dump.
 * $wgPropertySuggesterMinProbability - a float that sets a minimum threshold for suggestions (default 0.05)
 * $wgPropertySuggesterDeprecatedIds - a list of ints that blacklist suggestions
 * $wgPropertySuggesterInitialSuggestions - a list of ints that will be suggested when no statements exist
+* $wgPropertySuggesterClassifyingConditionWeight - a float between 0 and 1 that determines the weight that's given to classifying property ids relative to non classifying ones (default 0.5)
 
 ## Release notes
+
+### 4.0.0 (dev)
+* Allow changing the weight given to classifying conditions via the
+  `$wgPropertySuggesterClassifyingConditionWeight` setting. This only applies to the `item` context
+  if there is at least one classifying statement.
 
 ### 3.1.7 (2017-03-27)
 * Added compatibility with Wikibase DataModel 7.x

--- a/src/PropertySuggester/GetSuggestions.php
+++ b/src/PropertySuggester/GetSuggestions.php
@@ -57,6 +57,7 @@ class GetSuggestions extends ApiBase {
 		global $wgPropertySuggesterMinProbability;
 		global $wgPropertySuggesterClassifyingPropertyIds;
 		global $wgPropertySuggesterInitialSuggestions;
+		global $wgPropertySuggesterClassifyingConditionWeight;
 
 		$wikibaseRepo = WikibaseRepo::getDefaultInstance();
 		$store = $wikibaseRepo->getStore();
@@ -70,6 +71,7 @@ class GetSuggestions extends ApiBase {
 		$this->suggester->setDeprecatedPropertyIds( $wgPropertySuggesterDeprecatedIds );
 		$this->suggester->setClassifyingPropertyIds( $wgPropertySuggesterClassifyingPropertyIds );
 		$this->suggester->setInitialSuggestions( $wgPropertySuggesterInitialSuggestions );
+		$this->suggester->setClassifyingConditionWeight( $wgPropertySuggesterClassifyingConditionWeight );
 
 		$this->paramsParser = new SuggesterParamsParser( 500, $wgPropertySuggesterMinProbability );
 	}


### PR DESCRIPTION
Allow changing the weight given to classifying conditions via the `$wgPropertySuggesterClassifyingConditionWeight` setting. This only applies to the "item" context if there is at least one classifying statement.

During testing it turned out that the classifying conditions resulted in way better suggestions than the ones which are purely based on whether a Statement with a given Property id exists. Due to this, I want to be able to boost the weight of these classifying conditions, in order to address T132839.

https://phabricator.wikimedia.org/T132839