### PR TITLE
Fix all jslint errors

### DIFF
--- a/modules/ext.PropertySuggester.EntitySelector.js
+++ b/modules/ext.PropertySuggester.EntitySelector.js
@@ -32,9 +32,9 @@
 			this._oldCreate.apply( this, arguments );
 
 			var focusHandler = function( event ) {
-				if ( self._useSuggester()
-					&& self.element.val() === ''
-					&& !self.options.menu.element.is( ':visible' )
+				if ( self._useSuggester() &&
+					self.element.val() === '' &&
+					!self.options.menu.element.is( ':visible' )
 				) {
 					self.options.minTermLength = 0;
 					self._cache = {}; // is done in the entityselector on eachchange too
@@ -70,9 +70,7 @@
 					context: this._getPropertyContext(),
 					format: 'json',
 					language: this.options.language,
-					'continue': this._cache.term === term && this._cache.nextSuggestionOffset
-						? this._cache.nextSuggestionOffset
-						: 0
+					'continue': this._cache.term === term && this._cache.nextSuggestionOffset ? this._cache.nextSuggestionOffset : 0
 				};
 
 				if ( data.context === 'item' ) {
@@ -101,15 +99,14 @@
 		 * @return {wikibase.Entity|null}
 		 */
 		_getEntity: function() {
+			var $entityView;
 			try {
-				var $entityView = this.element.closest( ':wikibase-entityview' );
+				$entityView = this.element.closest( ':wikibase-entityview' );
 			} catch ( ex ) {
 				return null;
 			}
 
-			return $entityView.length > 0
-				? $entityView.data( 'entityview' ).option( 'value' )
-				: null;
+			return $entityView.length > 0 ? $entityView.data( 'entityview' ).option( 'value' ) : null;
 		},
 
 		/**
@@ -119,15 +116,14 @@
 		 * @return {string|null}
 		 */
 		_getPropertyId: function() {
+			var $statementview;
 			try {
-				var $statementview = this.element.closest( ':wikibase-statementview' );
+				$statementview = this.element.closest( ':wikibase-statementview' );
 			} catch ( ex ) {
 				return null;
 			}
 
-			var statement = $statementview.length > 0
-				? $statementview.data( 'statementview' ).option( 'value' )
-				: null;
+			var statement = $statementview.length > 0 ? $statementview.data( 'statementview' ).option( 'value' ) : null;
 
 			return statement ? statement.getClaim().getMainSnak().getPropertyId() : null;
 		},
@@ -183,9 +179,7 @@
 		 */
 		_isInNewStatementView: function() {
 			var $statementview = this.element.closest( ':wikibase-statementview' ),
-				value = $statementview.length > 0
-					? $statementview.data( 'statementview' ).option( 'value' )
-					: null;
+				value = $statementview.length > 0 ? $statementview.data( 'statementview' ).option( 'value' ) : null;
 
 			return !value;
 		}


### PR DESCRIPTION
This fixes all jslint errors. However, I have decided to go with the multiline option in 35-37 while a single line option in the tertiary operators for readability. Let me know if something needs changing. @addshore 