### PR TITLE
Add temporary workaround to be able to make Wikibase PSR-4 compatible

### DIFF
--- a/tests/phpunit/PropertySuggester/GetSuggestionsTest.php
+++ b/tests/phpunit/PropertySuggester/GetSuggestionsTest.php
@@ -7,7 +7,12 @@ use UsageException;
 use Wikibase\DataModel\Entity\EntityId;
 use Wikibase\DataModel\Entity\Property;
 use Wikibase\Repo\WikibaseRepo;
-use Wikibase\Test\Repo\Api\WikibaseApiTestCase;
+use Wikibase\Repo\Tests\Api\WikibaseApiTestCase;
+
+// FIXME: Remove this temporary workaround after the Wikibase class was moved.
+if ( !class_exists( WikibaseApiTestCase::class ) ) {
+	class_alias( \Wikibase\Test\Repo\Api\WikibaseApiTestCase::class, WikibaseApiTestCase::class );
+}
 
 /**
  * @covers PropertySuggester\GetSuggestions


### PR DESCRIPTION
This is a requirement to be able to make the `Wikibase\Repo\Tests\…` namespace in Wikibase.git PSR-4 compatible without breaking CI and builds. The same workaround must be applied in PropertySuggester and WikibaseQualityExternalValidation.

Please review and merge https://gerrit.wikimedia.org/r/325755 along with this.

The final move happens in https://gerrit.wikimedia.org/r/325894.

I suggest to merge, **tag and release** this change before the breaking change https://gerrit.wikimedia.org/r/325894.