### PR TITLE
Use hhvm 3.18 instead of 3.19 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ matrix:
     - env: DBTYPE=sqlite
       php: 7.0
     - env: DBTYPE=sqlite
-      php: hhvm
+      php: hhvm-3.18
     - env: DBTYPE=mysql
-      php: hhvm
+      php: hhvm-3.18
 
 before_script:
   - bash ./build/travis/before_script.sh


### PR DESCRIPTION
It might be the reason travis is failing
and we have 3.18 in production so it's better to use that anyway