### PR TITLE
Remove pinned HHVM version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
     - env: DBTYPE=sqlite
       php: 7.0
     - env: DBTYPE=sqlite
-      php: hhvm-3.18
+      php: hhvm
     - env: DBTYPE=mysql
-      php: hhvm-3.18
+      php: hhvm
 
 before_script:
   - bash ./build/travis/before_script.sh
@@ -24,4 +24,3 @@ script:
 
 after_success:
   - bash ./build/travis/after_script.sh
-


### PR DESCRIPTION
This reverts parts of #203. I assume the pinned version number is not necessary. Let's see how Travis thinks about this pull request.