### PR TITLE
Change all arrays to use the short PHP 5.5 syntax

### DIFF
--- a/PropertySuggester.alias.php
+++ b/PropertySuggester.alias.php
@@ -6,9 +6,9 @@
  * @ingroup Extensions
  */
 
-$specialPageAliases = array();
+$specialPageAliases = [];
 
 /** English (English) */
-$specialPageAliases['en'] = array(
-	'PropertySuggester' => array( 'PropertySuggester' ),
-);
+$specialPageAliases['en'] = [
+	'PropertySuggester' => [ 'PropertySuggester' ],
+];

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,6 @@
 <ruleset name="WikibaseMediaInfo">
 	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<!-- FIXME: The following should all be fixed. -->
-		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
 		<exclude name="MediaWiki.ControlStructures.AssignmentInControlStructures" />
 		<exclude name="PSR1.Classes.ClassDeclaration" />
 	</rule>

--- a/src/PropertySuggester/GetSuggestions.php
+++ b/src/PropertySuggester/GetSuggestions.php
@@ -147,7 +147,7 @@ class GetSuggestions extends ApiBase {
 	private function querySearchApi( $resultSize, $search, $language ) {
 		$searchEntitiesParameters = new DerivativeRequest(
 			$this->getRequest(),
-			array(
+			[
 				'limit' => $resultSize + 1,
 				'continue' => 0,
 				'search' => $search,
@@ -155,7 +155,7 @@ class GetSuggestions extends ApiBase {
 				'language' => $language,
 				'uselang' => $language,
 				'type' => Property::ENTITY_TYPE
-			)
+			]
 		);
 
 		$api = new ApiMain( $searchEntitiesParameters );
@@ -163,11 +163,11 @@ class GetSuggestions extends ApiBase {
 
 		$apiResult = $api->getResult()->getResultData(
 			null,
-			array(
-				'BC' => array(),
-				'Types' => array(),
+			[
+				'BC' => [],
+				'Types' => [],
 				'Strip' => 'all'
-			)
+			]
 		);
 
 		return $apiResult['search'];
@@ -177,43 +177,43 @@ class GetSuggestions extends ApiBase {
 	 * @see ApiBase::getAllowedParams()
 	 */
 	public function getAllowedParams() {
-		return array(
-			'entity' => array(
+		return [
+			'entity' => [
 				ApiBase::PARAM_TYPE => 'string',
-			),
-			'properties' => array(
+			],
+			'properties' => [
 				ApiBase::PARAM_TYPE => 'string',
 				ApiBase::PARAM_ISMULTI => true
-			),
-			'limit' => array(
+			],
+			'limit' => [
 				ApiBase::PARAM_TYPE => 'limit',
 				ApiBase::PARAM_DFLT => 7,
 				ApiBase::PARAM_MAX => ApiBase::LIMIT_SML1,
 				ApiBase::PARAM_MAX2 => ApiBase::LIMIT_SML2,
 				ApiBase::PARAM_MIN => 0,
 				ApiBase::PARAM_RANGE_ENFORCE => true,
-			),
+			],
 			'continue' => null,
-			'language' => array(
+			'language' => [
 				ApiBase::PARAM_TYPE => $this->languageCodes,
 				ApiBase::PARAM_DFLT => $this->getContext()->getLanguage()->getCode(),
-			),
-			'context' => array(
-				ApiBase::PARAM_TYPE => array( 'item', 'qualifier', 'reference' ),
+			],
+			'context' => [
+				ApiBase::PARAM_TYPE => [ 'item', 'qualifier', 'reference' ],
 				ApiBase::PARAM_DFLT => 'item',
-			),
-			'search' => array(
+			],
+			'search' => [
 				ApiBase::PARAM_TYPE => 'string',
 				ApiBase::PARAM_DFLT => '',
-			)
-		);
+			],
+		];
 	}
 
 	/**
 	 * @see ApiBase::getExamplesMessages()
 	 */
 	public function getExamplesMessages() {
-		return array(
+		return [
 			'action=wbsgetsuggestions&entity=Q4'
 			=> 'apihelp-wbsgetsuggestions-example-1',
 			'action=wbsgetsuggestions&entity=Q4&continue=10&limit=5'
@@ -224,7 +224,7 @@ class GetSuggestions extends ApiBase {
 			=> 'apihelp-wbsgetsuggestions-example-4',
 			'action=wbsgetsuggestions&properties=P21&context=reference'
 			=> 'apihelp-wbsgetsuggestions-example-5'
-		);
+		];
 	}
 
 }

--- a/src/PropertySuggester/ResultBuilder.php
+++ b/src/PropertySuggester/ResultBuilder.php
@@ -61,8 +61,8 @@ class ResultBuilder {
 	 * @return array[]
 	 */
 	public function createResultArray( array $suggestions, $language ) {
-		$entries = array();
-		$ids = array();
+		$entries = [];
+		$ids = [];
 		foreach ( $suggestions as $suggestion ) {
 			$id = $suggestion->getPropertyId();
 			$ids[] = $id;
@@ -71,7 +71,7 @@ class ResultBuilder {
 		$terms = $this->termIndex->getTermsOfEntities(
 			$ids,
 			null,
-			array( $language )
+			[ $language ]
 		);
 		$clusteredTerms = $this->clusterTerms( $terms );
 
@@ -89,16 +89,17 @@ class ResultBuilder {
 	 * @return array
 	 */
 	private function buildEntry( EntityId $id, array $clusteredTerms, Suggestion $suggestion ) {
-		$entry = array();
-		$entry['id'] = $id->getSerialization();
-		$entry['url'] = $this->entityTitleLookup->getTitleForId( $id )->getFullUrl();
-		$entry['rating'] = $suggestion->getProbability();
+		$entry = [
+			'id' => $id->getSerialization(),
+			'url' => $this->entityTitleLookup->getTitleForId( $id )->getFullUrl(),
+			'rating' => $suggestion->getProbability(),
+		];
 
 		/** @var TermIndexEntry[] $matchingTerms */
 		if ( isset( $clusteredTerms[$id->getSerialization()] ) ) {
 			$matchingTerms = $clusteredTerms[$id->getSerialization()];
 		} else {
-			$matchingTerms = array();
+			$matchingTerms = [];
 		}
 
 		foreach ( $matchingTerms as $term ) {
@@ -130,12 +131,12 @@ class ResultBuilder {
 	 * @return TermIndexEntry[][]
 	 */
 	private function clusterTerms( array $terms ) {
-		$clusteredTerms = array();
+		$clusteredTerms = [];
 
 		foreach ( $terms as $term ) {
 			$id = $term->getEntityId()->getSerialization();
 			if ( !isset( $clusteredTerms[$id] ) ) {
-				$clusteredTerms[$id] = array();
+				$clusteredTerms[$id] = [];
 			}
 			$clusteredTerms[$id][] = $term;
 		}
@@ -154,7 +155,7 @@ class ResultBuilder {
 
 		if ( preg_match( $this->searchPattern, $term->getText() ) ) {
 			if ( !isset( $entry['aliases'] ) ) {
-				$entry['aliases'] = array();
+				$entry['aliases'] = [];
 				ApiResult::setIndexedTagName( $entry['aliases'], 'alias' );
 			}
 			$entry['aliases'][] = $term->getText();
@@ -169,7 +170,7 @@ class ResultBuilder {
 	 */
 	public function mergeWithTraditionalSearchResults( array &$entries, array $searchResults, $resultSize ) {
 		// Avoid duplicates
-		$existingKeys = array();
+		$existingKeys = [];
 		foreach ( $entries as $entry ) {
 			$existingKeys[$entry['id']] = true;
 		}

--- a/src/PropertySuggester/Suggesters/SimpleSuggester.php
+++ b/src/PropertySuggester/Suggesters/SimpleSuggester.php
@@ -23,17 +23,17 @@ class SimpleSuggester implements SuggesterEngine {
 	/**
 	 * @var int[]
 	 */
-	private $deprecatedPropertyIds = array();
+	private $deprecatedPropertyIds = [];
 
 	/**
 	 * @var array Numeric property ids as keys, values are meaningless.
 	 */
-	private $classifyingPropertyIds = array();
+	private $classifyingPropertyIds = [];
 
 	/**
 	 * @var Suggestion[]
 	 */
-	private $initialSuggestions = array();
+	private $initialSuggestions = [];
 
 	/**
 	 * @var LoadBalancer
@@ -65,7 +65,7 @@ class SimpleSuggester implements SuggesterEngine {
 	 * @param int[] $initialSuggestionIds
 	 */
 	public function setInitialSuggestions( array $initialSuggestionIds ) {
-		$suggestions = array();
+		$suggestions = [];
 		foreach ( $initialSuggestionIds as $id ) {
 			$suggestions[] = new Suggestion( PropertyId::newFromNumber( $id ), 1.0 );
 		}
@@ -110,18 +110,23 @@ class SimpleSuggester implements SuggesterEngine {
 		}
 		$res = $dbr->select(
 			'wbs_propertypairs',
-			array( 'pid' => 'pid2', 'prob' => "sum(probability)/$count" ),
-			array( $condition,
-				   'pid2 NOT IN (' . $dbr->makeList( $excludedIds ) . ')',
-				   'context' => $context ),
+			[
+				'pid' => 'pid2',
+				'prob' => "sum(probability)/$count",
+			],
+			[
+				$condition,
+				'pid2 NOT IN (' . $dbr->makeList( $excludedIds ) . ')',
+				'context' => $context,
+			],
 			__METHOD__,
-			array(
+			[
 				'GROUP BY' => 'pid2',
 				'ORDER BY' => 'prob DESC',
 				'LIMIT'    => $limit,
 				'HAVING'   => 'prob > ' . floatval( $minProbability )
-				)
-			);
+			]
+		);
 		$this->lb->reuseConnection( $dbr );
 
 		return $this->buildResult( $res );
@@ -141,7 +146,7 @@ class SimpleSuggester implements SuggesterEngine {
 			return $propertyId->getNumericId();
 		}, $propertyIds );
 
-		return $this->getSuggestions( $numericIds, array(), $limit, $minProbability, $context );
+		return $this->getSuggestions( $numericIds, [], $limit, $minProbability, $context );
 	}
 
 	/**
@@ -155,8 +160,8 @@ class SimpleSuggester implements SuggesterEngine {
 	 * @return Suggestion[]
 	 */
 	public function suggestByItem( Item $item, $limit, $minProbability, $context ) {
-		$ids = array();
-		$idTuples = array();
+		$ids = [];
+		$idTuples = [];
 
 		foreach ( $item->getStatements()->toArray() as $statement ) {
 			$mainSnak = $statement->getMainSnak();
@@ -209,7 +214,7 @@ class SimpleSuggester implements SuggesterEngine {
 	 * @return Suggestion[]
 	 */
 	private function buildResult( ResultWrapper $res ) {
-		$resultArray = array();
+		$resultArray = [];
 		foreach ( $res as $row ) {
 			$pid = PropertyId::newFromNumber( $row->pid );
 			$suggestion = new Suggestion( $pid, $row->prob );

--- a/src/PropertySuggester/SuggestionGenerator.php
+++ b/src/PropertySuggester/SuggestionGenerator.php
@@ -75,7 +75,7 @@ class SuggestionGenerator {
 	 * @return Suggestion[]
 	 */
 	public function generateSuggestionsByPropertyList( array $propertyIdList, $limit, $minProbability, $context ) {
-		$propertyIds = array();
+		$propertyIds = [];
 		foreach ( $propertyIdList as $stringId ) {
 			$propertyIds[] = new PropertyId( $stringId );
 		}
@@ -97,12 +97,12 @@ class SuggestionGenerator {
 		}
 		$ids = $this->getMatchingIDs( $search, $language );
 
-		$id_set = array();
+		$id_set = [];
 		foreach ( $ids as $id ) {
 			$id_set[$id->getNumericId()] = true;
 		}
 
-		$matching_suggestions = array();
+		$matching_suggestions = [];
 		$count = 0;
 		foreach ( $suggestions as $suggestion ) {
 			if ( array_key_exists( $suggestion->getPropertyId()->getNumericId(), $id_set ) ) {
@@ -122,24 +122,24 @@ class SuggestionGenerator {
 	 */
 	private function getMatchingIDs( $search, $language ) {
 		$termIndexEntries = $this->termIndex->getTopMatchingTerms(
-			array(
-				new TermIndexSearchCriteria( array(
+			[
+				new TermIndexSearchCriteria( [
 					'termLanguage' => $language,
 					'termText' => $search
-				) )
-			),
-			array(
+				] )
+			],
+			[
 				TermIndexEntry::TYPE_LABEL,
 				TermIndexEntry::TYPE_ALIAS,
-			),
+			],
 			Property::ENTITY_TYPE,
-			array(
+			[
 				'caseSensitive' => false,
 				'prefixSearch' => true,
-			)
+			]
 		);
 
-		$ids = array();
+		$ids = [];
 		foreach ( $termIndexEntries as $entry ) {
 			$ids[] = $entry->getEntityId();
 		}

--- a/src/PropertySuggester/UpdateTable/Importer/BasicImporter.php
+++ b/src/PropertySuggester/UpdateTable/Importer/BasicImporter.php
@@ -42,11 +42,11 @@ class BasicImporter implements Importer {
 	 * @throws UnexpectedValueException
 	 */
 	private function doImport( $fileHandle, Database $db, ImportContext $importContext ) {
-		$accumulator = array();
+		$accumulator = [];
 		$batchSize = $importContext->getBatchSize();
 		$i = 0;
 		$header = fgetcsv( $fileHandle, 0, $importContext->getCsvDelimiter() ); //this is to get the csv-header
-		$expectedHeader = array( 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' );
+		$expectedHeader = [ 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' ];
 		if ( $header != $expectedHeader ) {
 			throw new UnexpectedValueException( "provided csv-file does not match the expected format:\n" . join( ',', $expectedHeader ) );
 		}
@@ -60,7 +60,7 @@ class BasicImporter implements Importer {
 				if ( ! $importContext->isQuiet() ) {
 					print "$i rows inserted\n";
 				}
-				$accumulator = array();
+				$accumulator = [];
 				if ( $data == false ) {
 					break;
 				}
@@ -68,8 +68,14 @@ class BasicImporter implements Importer {
 
 			$qid1 = is_numeric( $data[1] ) ? $data[1] : 0;
 
-			$accumulator[] = array( 'pid1' => $data[0], 'qid1' => $qid1, 'pid2' => $data[2], 'count' => $data[3],
-									'probability' => $data[4], 'context' => $data[5] );
+			$accumulator[] = [
+				'pid1' => $data[0],
+				'qid1' => $qid1,
+				'pid2' => $data[2],
+				'count' => $data[3],
+				'probability' => $data[4],
+				'context' => $data[5],
+			];
 		}
 	}
 

--- a/tests/evilMediaWikiBootstrap.php
+++ b/tests/evilMediaWikiBootstrap.php
@@ -22,7 +22,7 @@ require_once "$IP/includes/AutoLoader.php";
 require_once "$IP/includes/profiler/Profiler.php";
 
 # Start the profiler
-$wgProfiler = array();
+$wgProfiler = [];
 if ( file_exists( "$IP/StartProfiler.php" ) ) {
 	require "$IP/StartProfiler.php";
 }
@@ -39,7 +39,7 @@ foreach ( get_defined_vars() as $key => $var ) {
 }
 
 global $wgAutoloadClasses;
-$wgAutoloadClasses = array();
+$wgAutoloadClasses = [];
 
 if ( defined( 'MW_CONFIG_CALLBACK' ) ) {
 	# Use a callback function to configure MediaWiki

--- a/tests/phpunit/PropertySuggester/GetSuggestionsTest.php
+++ b/tests/phpunit/PropertySuggester/GetSuggestionsTest.php
@@ -63,10 +63,16 @@ class GetSuggestionsTest extends WikibaseApiTestCase {
 		$ip56 = (int)substr( $p56, 1 );
 		$ip72 = (int)substr( $p72, 1 );
 
-		$row = array( 'pid1' => $ip56, 'qid1' => 0, 'pid2' => $ip72, 'count' => 1,
-			'probability' => 0.3, 'context' => 'item' );
+		$row = [
+			'pid1' => $ip56,
+			'qid1' => 0,
+			'pid2' => $ip72,
+			'count' => 1,
+			'probability' => 0.3,
+			'context' => 'item',
+		];
 
-		$this->db->insert( 'wbs_propertypairs', array( $row ) );
+		$this->db->insert( 'wbs_propertypairs', [ $row ] );
 	}
 
 	public function testDatabaseHasRows() {
@@ -77,8 +83,8 @@ class GetSuggestionsTest extends WikibaseApiTestCase {
 
 		$res = $this->db->select(
 			'wbs_propertypairs',
-			array( 'pid1', 'pid2' ),
-			array( 'pid1' => $ip56, 'pid2' => $ip72 )
+			[ 'pid1', 'pid2' ],
+			[ 'pid1' => $ip56, 'pid2' => $ip72 ]
 		);
 		$this->assertEquals( 1, $res->numRows() );
 	}
@@ -87,12 +93,12 @@ class GetSuggestionsTest extends WikibaseApiTestCase {
 		$p56 = self::$idMap['%P56%'];
 		$p72 = self::$idMap['%P72%'];
 
-		$params = array(
+		$params = [
 			'action' => 'wbsgetsuggestions',
 			'properties' => $p56,
 			'search' => '*',
 			'context' => 'item'
-		);
+		];
 		$res = $this->doApiRequest( $params );
 		$result = $res[0];
 
@@ -106,13 +112,13 @@ class GetSuggestionsTest extends WikibaseApiTestCase {
 	public function testExecutionWithSearch() {
 		$p56 = self::$idMap['%P56%'];
 
-		$params = array(
+		$params = [
 			'action' => 'wbsgetsuggestions',
 			'properties' => $p56,
 			'search' => 'IdontExist',
 			'continue' => 0,
 			'context' => 'item'
-		);
+		];
 		$res = $this->doApiRequest( $params );
 		$result = $res[0];
 
@@ -123,11 +129,11 @@ class GetSuggestionsTest extends WikibaseApiTestCase {
 
 	public function testExecutionWithInvalidContext() {
 		$p56 = self::$idMap['%P56%'];
-		$params = array(
+		$params = [
 			'action' => 'wbsgetsuggestions',
 			'properties' => $p56,
 			'context' => 'delete all the things!'
-		);
+		];
 
 		$this->setExpectedException( ApiUsageException::class );
 		$this->doApiRequest( $params );

--- a/tests/phpunit/PropertySuggester/SuggesterParamsParserTest.php
+++ b/tests/phpunit/PropertySuggester/SuggesterParamsParserTest.php
@@ -22,7 +22,7 @@ class SuggesterParamsParserTest extends MediaWikiTestCase {
 
 	private $defaultSuggesterResultSize = 100;
 	private $defaultMinProbability = 0.01;
-	private $defaultParams = array(
+	private $defaultParams = [
 		'entity' => null,
 		'properties' => null,
 		'continue' => 10,
@@ -30,7 +30,7 @@ class SuggesterParamsParserTest extends MediaWikiTestCase {
 		'language' => 'en',
 		'search' => '',
 		'context' => 'item',
-	);
+	];
 
 	public function setUp() {
 		parent::setUp();
@@ -62,7 +62,7 @@ class SuggesterParamsParserTest extends MediaWikiTestCase {
 		);
 
 		$this->assertEquals( null, $params->entity );
-		$this->assertEquals( array( 'P31' ), $params->properties );
+		$this->assertEquals( [ 'P31' ], $params->properties );
 		$this->assertEquals( 'en', $params->language );
 		$this->assertEquals( 10, $params->continue );
 		$this->assertEquals( 5, $params->limit );
@@ -77,7 +77,7 @@ class SuggesterParamsParserTest extends MediaWikiTestCase {
 	 */
 	public function testSuggestionWithoutEntityOrProperties() {
 		$this->paramsParser->parseAndValidate(
-			array( 'entity' => null, 'properties' => null )
+			[ 'entity' => null, 'properties' => null ]
 		);
 	}
 
@@ -86,7 +86,7 @@ class SuggesterParamsParserTest extends MediaWikiTestCase {
 	 */
 	public function testSuggestionWithEntityAndProperties() {
 		$this->paramsParser->parseAndValidate(
-			array( 'entity' => 'Q1', 'properties' => array( 'P31' ) )
+			[ 'entity' => 'Q1', 'properties' => [ 'P31' ] ]
 		);
 	}
 
@@ -95,7 +95,7 @@ class SuggesterParamsParserTest extends MediaWikiTestCase {
 	 */
 	public function testSuggestionWithNonNumericContinue() {
 		$this->paramsParser->parseAndValidate(
-			array( 'entity' => 'Q1', 'properties' => null, 'continue' => 'drop' )
+			[ 'entity' => 'Q1', 'properties' => null, 'continue' => 'drop' ]
 		);
 	}
 

--- a/tests/phpunit/PropertySuggester/Suggesters/SimpleSuggesterTest.php
+++ b/tests/phpunit/PropertySuggester/Suggesters/SimpleSuggesterTest.php
@@ -28,23 +28,24 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	private $suggester;
 
 	private function row( $pid1, $qid1, $pid2, $count, $probability, $context ) {
-		return array(
+		return [
 			'pid1' => $pid1,
 			'qid1' => $qid1,
 			'pid2' => $pid2,
 			'count' => $count,
 			'probability' => $probability,
 			'context' => $context
-		);
+		];
 	}
 
 	public function addDBData() {
-		$rows = array();
-		$rows[] = $this->row( 1, 0, 2, 100, 0.1, 'item' );
-		$rows[] = $this->row( 1, 0, 3, 50, 0.05, 'item' );
-		$rows[] = $this->row( 2, 0, 3, 100, 0.3, 'item' );
-		$rows[] = $this->row( 2, 0, 4, 200, 0.2, 'item' );
-		$rows[] = $this->row( 3, 0, 1, 100, 0.5, 'item' );
+		$rows = [
+			$this->row( 1, 0, 2, 100, 0.1, 'item' ),
+			$this->row( 1, 0, 3, 50, 0.05, 'item' ),
+			$this->row( 2, 0, 3, 100, 0.3, 'item' ),
+			$this->row( 2, 0, 4, 200, 0.2, 'item' ),
+			$this->row( 3, 0, 1, 100, 0.5, 'item' ),
+		];
 
 		$this->db->insert( 'wbs_propertypairs', $rows );
 	}
@@ -53,17 +54,17 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 		parent::setUp();
 
 		$this->tablesUsed[] = 'wbs_propertypairs';
-		$lb = new LoadBalancerSingle( array( "connection" => $this->db ) );
+		$lb = new LoadBalancerSingle( [ 'connection' => $this->db ] );
 		$this->suggester = new SimpleSuggester( $lb );
 	}
 
 	public function testDatabaseHasRows() {
-		$res = $this->db->select( 'wbs_propertypairs', array( 'pid1', 'pid2' ) );
+		$res = $this->db->select( 'wbs_propertypairs', [ 'pid1', 'pid2' ] );
 		$this->assertEquals( 5, $res->numRows() );
 	}
 
 	public function testSuggestByPropertyIds() {
-		$ids = array( new PropertyId( 'p1' ) );
+		$ids = [ new PropertyId( 'p1' ) ];
 
 		$res = $this->suggester->suggestByPropertyIds( $ids, 100, 0.0, 'item' );
 
@@ -86,9 +87,9 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	}
 
 	public function testDeprecatedProperties() {
-		$ids = array( new PropertyId( 'p1' ) );
+		$ids = [ new PropertyId( 'p1' ) ];
 
-		$this->suggester->setDeprecatedPropertyIds( array( 2 ) );
+		$this->suggester->setDeprecatedPropertyIds( [ 2 ] );
 
 		$res = $this->suggester->suggestByPropertyIds( $ids, 100, 0.0, 'item' );
 
@@ -100,14 +101,14 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	}
 
 	public function testEmptyResult() {
-		$this->assertEmpty( $this->suggester->suggestByPropertyIds( array(), 10, 0.01, 'item' ) );
+		$this->assertEmpty( $this->suggester->suggestByPropertyIds( [], 10, 0.01, 'item' ) );
 	}
 
 	public function testInitialSuggestionsResult() {
-		$this->suggester->setInitialSuggestions( array( 42 ) );
+		$this->suggester->setInitialSuggestions( [ 42 ] );
 		$this->assertEquals(
-			array( new Suggestion( new PropertyId( "P42" ), 1.0 ) ),
-			$this->suggester->suggestByPropertyIds( array(), 10, 0.01, 'item' )
+			[ new Suggestion( new PropertyId( 'P42' ), 1.0 ) ],
+			$this->suggester->suggestByPropertyIds( [], 10, 0.01, 'item' )
 		);
 	}
 
@@ -115,14 +116,14 @@ class SimpleSuggesterTest extends MediaWikiTestCase {
 	 * @expectedException InvalidArgumentException
 	 */
 	public function testInvalidLimit() {
-		$this->suggester->suggestByPropertyIds( array(), '10', 0.01, 'item' );
+		$this->suggester->suggestByPropertyIds( [], '10', 0.01, 'item' );
 	}
 
 	/**
 	 * @expectedException InvalidArgumentException
 	 */
 	public function testInvalidMinProbability() {
-		$this->suggester->suggestByPropertyIds( array(), 10, '0.01', 'item' );
+		$this->suggester->suggestByPropertyIds( [], 10, '0.01', 'item' );
 	}
 
 }

--- a/tests/phpunit/PropertySuggester/SuggestionGeneratorTest.php
+++ b/tests/phpunit/PropertySuggester/SuggestionGeneratorTest.php
@@ -65,24 +65,24 @@ class SuggestionGeneratorTest extends MediaWikiTestCase {
 		$p15 = new PropertyId( 'P15' );
 		$p23 = new PropertyId( 'P23' );
 
-		$suggestions = array(
+		$suggestions = [
 			new Suggestion( $p12, 0.9 ), // this will stay at pos 0
 			new Suggestion( $p23, 0.8 ), // this doesn't match
 			new Suggestion( $p7, 0.7 ), // this will go to pos 1
 			new Suggestion( $p15, 0.6 ) // this is outside of resultSize
-		);
+		];
 
 		$resultSize = 2;
 
 		$this->termIndex->expects( $this->any() )
 			->method( 'getTopMatchingTerms' )
 			->will( $this->returnValue(
-				$this->getTermIndexEntryArrayWithIds( array( $p7, $p10, $p15, $p12 ) )
+				$this->getTermIndexEntryArrayWithIds( [ $p7, $p10, $p15, $p12 ] )
 			) );
 
 		$result = $this->suggestionGenerator->filterSuggestions( $suggestions, 'foo', 'en', $resultSize );
 
-		$this->assertEquals( array( $suggestions[0], $suggestions[2] ), $result );
+		$this->assertEquals( [ $suggestions[0], $suggestions[2] ], $result );
 	}
 
 	/**
@@ -91,14 +91,14 @@ class SuggestionGeneratorTest extends MediaWikiTestCase {
 	 * @return TermIndexEntry[]
 	 */
 	private function getTermIndexEntryArrayWithIds( $ids ) {
-		$termIndexEntries = array();
+		$termIndexEntries = [];
 		foreach ( $ids as $i => $id ) {
-			$termIndexEntries[] = new TermIndexEntry( array(
+			$termIndexEntries[] = new TermIndexEntry( [
 				'entityId' => $id,
 				'termLanguage' => 'en',
 				'termText' => "kitten$i",
 				'termType' => TermIndexEntry::TYPE_LABEL
-			) );
+			] );
 		}
 		return $termIndexEntries;
 	}
@@ -107,33 +107,34 @@ class SuggestionGeneratorTest extends MediaWikiTestCase {
 		$resultSize = 2;
 
 		$result = $this->suggestionGenerator->filterSuggestions(
-			array( 1, 2, 3, 4 ),
+			[ 1, 2, 3, 4 ],
 			'',
 			'en',
 			$resultSize
 		);
 
-		$this->assertEquals( array( 1, 2 ), $result );
+		$this->assertEquals( [ 1, 2 ], $result );
 	}
 
 	public function testGenerateSuggestionsWithPropertyList() {
-		$properties = array();
-		$properties[] = new PropertyId( 'P12' );
-		$properties[] = new PropertyId( 'P13' );
-		$properties[] = new PropertyId( 'P14' );
+		$properties = [
+			new PropertyId( 'P12' ),
+			new PropertyId( 'P13' ),
+			new PropertyId( 'P14' ),
+		];
 
 		$this->suggester->expects( $this->any() )
 			->method( 'suggestByPropertyIds' )
 			->with( $this->equalTo( $properties ) )
-			->will( $this->returnValue( array( 'foo' ) ) );
+			->will( $this->returnValue( [ 'foo' ] ) );
 
 		$result1 = $this->suggestionGenerator->generateSuggestionsByPropertyList(
-			array( 'P12', 'p13', 'P14' ),
+			[ 'P12', 'p13', 'P14' ],
 			100,
 			0.0,
 			'item'
 		);
-		$this->assertEquals( $result1, array( 'foo' ) );
+		$this->assertEquals( $result1, [ 'foo' ] );
 	}
 
 	public function testGenerateSuggestionsWithItem() {
@@ -151,10 +152,10 @@ class SuggestionGeneratorTest extends MediaWikiTestCase {
 		$this->suggester->expects( $this->any() )
 			->method( 'suggestByItem' )
 			->with( $this->equalTo( $item ) )
-			->will( $this->returnValue( array( 'foo' ) ) );
+			->will( $this->returnValue( [ 'foo' ] ) );
 
 		$result3 = $this->suggestionGenerator->generateSuggestionsByItem( 'Q42', 100, 0.0, 'item' );
-		$this->assertEquals( $result3, array( 'foo' ) );
+		$this->assertEquals( $result3, [ 'foo' ] );
 	}
 
 	/**

--- a/tests/phpunit/PropertySuggester/UpdateTable/UpdateTableTest.php
+++ b/tests/phpunit/PropertySuggester/UpdateTable/UpdateTableTest.php
@@ -24,7 +24,7 @@ class UpdateTableTest extends MediaWikiTestCase {
 	/**
 	 * @var string[]
 	 */
-	private $rowHeader = array( 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' );
+	private $rowHeader = [ 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' ];
 
 	public function setUp() {
 		parent::setUp();
@@ -34,30 +34,30 @@ class UpdateTableTest extends MediaWikiTestCase {
 	}
 
 	public function getRows() {
-		$rows1 = array(
-			array( 1, 0, 2, 100, 0.1, 'item' ),
-			array( 1, 0, 3, 50, 0.05, 'item' ),
-			array( 2, 0, 3, 100, 0.1, 'item' ),
-			array( 2, 0, 4, 200, 0.2, 'item' ),
-			array( 3, 0, 1, 123, 0.5, 'item' ),
-		);
+		$rows1 = [
+			[ 1, 0, 2, 100, 0.1, 'item' ],
+			[ 1, 0, 3, 50, 0.05, 'item' ],
+			[ 2, 0, 3, 100, 0.1, 'item' ],
+			[ 2, 0, 4, 200, 0.2, 'item' ],
+			[ 3, 0, 1, 123, 0.5, 'item' ],
+		];
 
-		$rows2 = array();
+		$rows2 = [];
 		for ( $i = 0; $i < 1100; $i++ ) {
-			$rows2[] = array( $i, 0, 2, 100, 0.1, 'item' );
+			$rows2[] = [ $i, 0, 2, 100, 0.1, 'item' ];
 		}
 
-		return array(
-			array( $rows1 ),
-			array( $rows2 ),
-		);
+		return [
+			[ $rows1 ],
+			[ $rows2 ],
+		];
 	}
 
 	/**
 	 * @dataProvider getRows
 	 */
 	public function testRewriteNativeStrategy( array $rows ) {
-		$args = array( 'file' => $this->testfilename, 'quiet' => true, 'use-loaddata' => true );
+		$args = [ 'file' => $this->testfilename, 'quiet' => true, 'use-loaddata' => true ];
 		$this->runScriptAndAssert( $args, $rows );
 	}
 
@@ -65,7 +65,7 @@ class UpdateTableTest extends MediaWikiTestCase {
 	 * @dataProvider getRows
 	 */
 	public function testRewriteWithSQLInserts( array $rows ) {
-		$args = array( 'file' => $this->testfilename, 'quiet' => true );
+		$args = [ 'file' => $this->testfilename, 'quiet' => true ];
 		$this->runScriptAndAssert( $args, $rows );
 	}
 
@@ -77,16 +77,16 @@ class UpdateTableTest extends MediaWikiTestCase {
 		if ( count( $rows ) < 100 ) {
 			$this->assertSelect(
 				'wbs_propertypairs',
-				array( 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' ),
-				array(),
+				[ 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' ],
+				[],
 				$rows
 			);
 		} else { // assertSelect is too slow to compare 1100 rows... just check the size
 			$this->assertSelect(
 				'wbs_propertypairs',
-				array( 'count' => 'count(*)' ),
-				array(),
-				array( array( count( $rows ) ) )
+				[ 'count' => 'count(*)' ],
+				[],
+				[ [ count( $rows ) ] ]
 			);
 		}
 	}


### PR DESCRIPTION
I did this replacement manually (assisted by PHPStorm), and took the chance to fix a few minor syntax issues in the code lines I had to touch anyway:
* Replaced double with single quotes on a string.
* Split some overly long array declarations.
* Merged multiple `$array[] = …` into a single `$array = [ … ]`.