### PR TITLE
Update Wikibase CodeSniffer rule set to 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+composer.lock
 vendor/

--- a/PropertySuggesterHooks.php
+++ b/PropertySuggesterHooks.php
@@ -1,22 +1,29 @@
 <?php
 
+namespace PropertySuggester;
+
+use DatabaseUpdater;
+use OutputPage;
+use Skin;
 use Wikibase\DataModel\Entity\Item;
 use Wikibase\Repo\WikibaseRepo;
 
+/**
+ * @license GNU GPL v2+
+ * @author BP2013N2
+ */
 final class PropertySuggesterHooks {
 
 	/**
 	 * Handler for the BeforePageDisplay hook, injects special behaviour
 	 * for PropertySuggestions in the EntitySuggester (if page is in EntityNamespace)
 	 *
-	 *
 	 * @param OutputPage $out
 	 * @param Skin $skin
-	 * @return bool
 	 */
 	public static function onBeforePageDisplay( OutputPage &$out, Skin &$skin ) {
 		if ( $out->getRequest()->getCheck( 'nosuggestions' ) ) {
-			return true;
+			return;
 		}
 
 		$entityNamespaceLookup = WikibaseRepo::getDefaultInstance()->getEntityNamespaceLookup();
@@ -31,24 +38,20 @@ final class PropertySuggesterHooks {
 		}
 
 		if ( $out->getTitle() === null || $out->getTitle()->getNamespace() !== $itemNamespace ) {
-			return true;
+			return;
 		}
 
 		$out->addModules( 'ext.PropertySuggester.EntitySelector' );
-		return true;
 	}
 
 	/**
 	 * @param DatabaseUpdater $updater
-	 * @return bool
 	 */
 	public static function onCreateSchema( DatabaseUpdater $updater ) {
 		$updater->addExtensionTable(
 			'wbs_propertypairs',
 			__DIR__ . '/sql/create_propertypairs.sql'
 		);
-
-		return true;
 	}
 
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",
 		"satooshi/php-coveralls": "dev-master",
-		"wikibase/wikibase-codesniffer": "^0.1.0",
+		"wikibase/wikibase-codesniffer": "^0.2.0",
 		"wikimedia/testing-access-wrapper": "~1.0"
 	},
 	"autoload": {

--- a/extension.json
+++ b/extension.json
@@ -40,8 +40,8 @@
 		"remoteExtPath": "PropertySuggester"
 	},
 	"Hooks": {
-		"BeforePageDisplay": "PropertySuggesterHooks::onBeforePageDisplay",
-		"LoadExtensionSchemaUpdates": "PropertySuggesterHooks::onCreateSchema"
+		"BeforePageDisplay": "PropertySuggester\\PropertySuggesterHooks::onBeforePageDisplay",
+		"LoadExtensionSchemaUpdates": "PropertySuggester\\PropertySuggesterHooks::onCreateSchema"
 	},
 	"config": {
 		"PropertySuggesterDeprecatedIds": [

--- a/maintenance/UpdateTable.php
+++ b/maintenance/UpdateTable.php
@@ -15,7 +15,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  * Maintenance script to load property pair occurrence probability table from given csv file
  *
  * @author BP2013N2
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class UpdateTable extends Maintenance {
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,16 +1,15 @@
 <?xml version="1.0"?>
-<ruleset name="WikibaseMediaInfo">
-	<rule ref="vendor/wikibase/wikibase-codesniffer/Wikibase">
+<ruleset name="PropertySuggester">
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<!-- FIXME: The following should all be fixed. -->
 		<exclude name="MediaWiki.ControlStructures.AssignmentInControlStructures" />
-		<exclude name="PSR1.Classes.ClassDeclaration" />
 	</rule>
 
 	<!-- Exceptions -->
 
 	<rule ref="Generic.Files.LineLength">
 		<properties>
-			<property name="lineLimit" value="130" />
+			<property name="lineLimit" value="115" />
 		</properties>
 	</rule>
 

--- a/src/PropertySuggester/GetSuggestions.php
+++ b/src/PropertySuggester/GetSuggestions.php
@@ -18,7 +18,7 @@ use Wikibase\TermIndex;
 /**
  * API module to get property suggestions.
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class GetSuggestions extends ApiBase {
 

--- a/src/PropertySuggester/ResultBuilder.php
+++ b/src/PropertySuggester/ResultBuilder.php
@@ -13,7 +13,7 @@ use Wikibase\Lib\Store\EntityTitleLookup;
  * ResultBuilder builds Json-compatible array structure from suggestions
  *
  * @author BP2013N2
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class ResultBuilder {
 

--- a/src/PropertySuggester/SuggesterParamsParser.php
+++ b/src/PropertySuggester/SuggesterParamsParser.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * Parses the suggester parameters
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class SuggesterParamsParser {
 
@@ -43,7 +43,9 @@ class SuggesterParamsParser {
 		$result->properties = $params['properties'];
 
 		if ( !( $result->entity xor $result->properties ) ) {
-			throw new InvalidArgumentException( 'provide either entity-id parameter \'entity\' or a list of properties \'properties\'' );
+			throw new InvalidArgumentException(
+				'provide either entity-id parameter \'entity\' or a list of properties \'properties\''
+			);
 		}
 		if ( !( is_null( $params['continue'] ) || is_numeric( $params['continue'] ) ) ) {
 			throw new InvalidArgumentException( 'continue must be int!' );

--- a/src/PropertySuggester/Suggesters/SimpleSuggester.php
+++ b/src/PropertySuggester/Suggesters/SimpleSuggester.php
@@ -16,7 +16,7 @@ use Wikimedia\Rdbms\ResultWrapper;
  * a Suggester implementation that creates suggestion via MySQL
  * Needs the wbs_propertypairs table filled with pair probabilities.
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class SimpleSuggester implements SuggesterEngine {
 

--- a/src/PropertySuggester/Suggesters/SuggesterEngine.php
+++ b/src/PropertySuggester/Suggesters/SuggesterEngine.php
@@ -8,7 +8,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * interface for (Property-)Suggester
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 interface SuggesterEngine {
 

--- a/src/PropertySuggester/Suggesters/Suggestion.php
+++ b/src/PropertySuggester/Suggesters/Suggestion.php
@@ -7,7 +7,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 /**
  * Suggestion returned by a SuggesterEngine
  *
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class Suggestion {
 

--- a/src/PropertySuggester/SuggestionGenerator.php
+++ b/src/PropertySuggester/SuggestionGenerator.php
@@ -18,7 +18,7 @@ use Wikibase\TermIndexEntry;
  * API module helper to generate property suggestions.
  *
  * @author BP2013N2
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class SuggestionGenerator {
 

--- a/src/PropertySuggester/UpdateTable/ImportContext.php
+++ b/src/PropertySuggester/UpdateTable/ImportContext.php
@@ -8,7 +8,7 @@ use Wikimedia\Rdbms\LoadBalancer;
  * Context for importing data from a csv file to a db table using a Importer strategy
  *
  * @author BP2013N2
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class ImportContext {
 

--- a/src/PropertySuggester/UpdateTable/Importer/BasicImporter.php
+++ b/src/PropertySuggester/UpdateTable/Importer/BasicImporter.php
@@ -11,7 +11,7 @@ use Wikimedia\Rdbms\Database;
  * are supported by the dbms.
  *
  * @author BP2013N2
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 class BasicImporter implements Importer {
 
@@ -47,9 +47,13 @@ class BasicImporter implements Importer {
 		$i = 0;
 		$header = fgetcsv( $fileHandle, 0, $importContext->getCsvDelimiter() ); //this is to get the csv-header
 		$expectedHeader = [ 'pid1', 'qid1', 'pid2', 'count', 'probability', 'context' ];
+
 		if ( $header != $expectedHeader ) {
-			throw new UnexpectedValueException( "provided csv-file does not match the expected format:\n" . join( ',', $expectedHeader ) );
+			throw new UnexpectedValueException(
+				"provided csv-file does not match the expected format:\n" . join( ',', $expectedHeader )
+			);
 		}
+
 		while ( true ) {
 			$data = fgetcsv( $fileHandle, 0, $importContext->getCsvDelimiter() );
 

--- a/src/PropertySuggester/UpdateTable/Importer/Importer.php
+++ b/src/PropertySuggester/UpdateTable/Importer/Importer.php
@@ -8,7 +8,7 @@ use PropertySuggester\UpdateTable\ImportContext;
  * A interface for strategies, which imports entries from CSV file into DB table
  *
  * @author BP2013N2
- * @licence GNU GPL v2+
+ * @license GNU GPL v2+
  */
 interface Importer {
 

--- a/tests/phpunit/PropertySuggester/PropertySuggesterHooksTest.php
+++ b/tests/phpunit/PropertySuggester/PropertySuggesterHooksTest.php
@@ -3,7 +3,6 @@
 namespace PropertySuggester;
 
 use MediaWikiTestCase;
-use PropertySuggesterHooks;
 use RequestContext;
 use Title;
 use Wikibase\DataModel\Entity\EntityId;
@@ -12,7 +11,7 @@ use Wikibase\DataModel\Entity\PropertyId;
 use Wikibase\Repo\WikibaseRepo;
 
 /**
- * @covers PropertySuggesterHooks
+ * @covers \PropertySuggester\PropertySuggesterHooks
  *
  * @group PropertySuggester
  * @group Wikibase


### PR DESCRIPTION
This patch also:
* Removes meaningless return true from hooks. This is the default and
  does not do anything.
* Adds a namespace to the only class that was not in a namespace.